### PR TITLE
Make MapStruct call @AfterMapping for superbuilders

### DIFF
--- a/src/main/java/com/mycompany/mapper/SourceTargetChildMapper.java
+++ b/src/main/java/com/mycompany/mapper/SourceTargetChildMapper.java
@@ -35,8 +35,7 @@ public abstract class SourceTargetChildMapper {
     public abstract TargetChild toTarget(Source s);
 
     @AfterMapping
-    public void afterMapping(Source s, @MappingTarget TargetChild.TargetChildBuilder target) {
+    public void afterMapping(Source s, @MappingTarget TargetChild.TargetChildBuilder<?, ?> target) {
         target.afterMappingField(AFTER_MAPPING_FIELD_VAL);
-        target.build();
     }
 }


### PR DESCRIPTION
- Builder type should be parametrized
- You should not build the builder, MapStruct will take care of it

Disclaimer: I did not test this changes but were able to make it work in my own project using MapStruct and Lombok with @SuperBuilder